### PR TITLE
fix: slogchange listener bug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,7 @@ class GithubCorner extends HTMLElement {
     svgSlot.addEventListener('slotchange', () => {
       this.#cloneNodes.forEach((n) => {
         if (this.#svgContainer.contains(n)) {
-          this.removeChild(n)
+          this.#svgContainer.removeChild(n)
         }
       })
 
@@ -86,9 +86,7 @@ class GithubCorner extends HTMLElement {
         .assignedNodes()
         .filter((n) => n.nodeName === 'svg')
       this.#cloneNodes = svgNodes.map((n) => n.cloneNode(true))
-      this.#cloneNodes.forEach((n) => {
-        this.#svgContainer.append(n.cloneNode(true))
-      })
+      this.#cloneNodes.forEach((n) => this.#svgContainer.append(n))
     })
   }
 


### PR DESCRIPTION
Description:
svg slot element does not append and remove correctly inside svg container.

Root cause:
append and remove logic in `slotchange` listener is incorrect.