### PR TITLE
refactor: use CSSStyleSheet object to adopt style sheet

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,9 +1,15 @@
 :host {
+  --github-corner-size: 5rem;
+}
+
+:host {
   display: block;
   position: absolute;
   cursor: pointer;
   overflow: hidden;
   clip-path: polygon(0% 0%, 100% 0%, 100% 100%);
+  width: var(--github-corner-size);
+  height: var(--github-corner-size);
 }
 
 :host([placement='top-left']) {


### PR DESCRIPTION
Use [CSSStyleSheet](https://developer.mozilla.org/zh-TW/docs/Web/API/CSSStyleSheet) to change the custom property of size dynamically inside shadow DOM, so that we can prevent modifying inline style of github-corner element when the size attribute has changed.

(This PR can not merge since Safari does not support [adoptedStyleSheets](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets)  & [CSSStyleSheet.replaceSync()](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/replaceSync) API yet.)